### PR TITLE
expands proof in Appendix A to improve clarity

### DIFF
--- a/paper/generalized_rebar.tex
+++ b/paper/generalized_rebar.tex
@@ -693,17 +693,26 @@ One could also train our control variate off-policy, as in $Q$-prop~\citep{gu201
 \section{The RELAX Algorithm}
 \label{relax proof}
 
-We prove that $\hat g_\textnormal{RELAX}$ is unbiased. Following~\cite{tucker2017rebar}:
-%
-\begin{align}
-\E \left[ \hat g_\textnormal{RELAX} \right] = \\
-\E_{p(b|\theta)} \! \left[\left[ f(b) - \E_{p(z|b, \theta)} \! \left[c_\phi(z) \right] \right]\PT \log p(b|\theta)  - \PT \E_{p(z|b, \theta)} \! \left[c_\phi(z) \right] \right] + \PT\E_{p(z|\theta)} \! \left[ c_\phi(z) \right] \span & \nonumber\\
-&= \PT \E_{p(b|\theta)} \! \left[ f(b) - \E_{p(z|b, \theta)}\left[ c_\phi(z) \right]  \right] + \PT\E_{p(z|\theta)} \! \left[ c_\phi(z) \right]\nonumber\\
-&= \PT \E_{p(b|\theta)} \! \left[ f(b) \right] - \PT\E_{p(z|\theta)} \! \left[ c_\phi(z) \right] + \PT\E_{p(z|\theta)} \! \left[ c_\phi(z) \right]
-= \PT \expectedLoss{}%&= \E_{p(\epsilon, \hat{\epsilon})}\Big[\left( f(H(T(\epsilon, \theta))) - c_\phi(T(\epsilon, \theta))  \right) \PT \log p(H(T(\epsilon, \theta))|\theta) - \PT c_\phi(\hat{T}(\hat{\epsilon}, H(T(\epsilon, \theta)), \theta)) \Big]\nonumber\\
-%&\qquad + \PT\E_{p(\epsilon)}\left[ c_\phi(T(\epsilon, \theta)) \right]
-\end{align}
-%
+\begin{proof}
+	We show that $\hat g_\textnormal{RELAX}$ is an unbiased estimator of $\frac{\partial}{\partial \theta} \mathbb{E}_{p(b \vert \theta)} \left[ f(b) \right]$. The estimator is
+	
+	\begin{align*}
+	\E_{p(b|\theta)} \! \left[\left[ f(b) - \E_{p(\tilde{z}|b, \theta)} \! \left[c_\phi(\tilde{z}) \right] \right]\PT \log p(b|\theta)  - \PT \E_{p(\tilde{z}|b, \theta)} \! \left[c_\phi(\tilde{z}) \right] \right] + \PT\E_{p(z|\theta)} \! \left[ c_\phi(z) \right]. \span & \nonumber \\
+	\end{align*}
+	Expanding the expectation for clarity of exposition, we account for each term separately:
+	\begin{align}
+	& \E_{p(b|\theta)} \! \left[ f(b) \PT \log p(b|\theta)  \right] \label{one}\\ 
+	& - \E_{p(b|\theta)} \left[ \E_{p(\tilde{z}|b, \theta)} \! \left[c_\phi (\tilde{z}) \right] \PT \log p(b|\theta)  \right] \label{two}\\
+	& - \E_{p(b|\theta)}  \left[ \PT \E_{p(\tilde{z}|b, \theta)} \! \left[c_\phi(\tilde{z}) \right] \right] \label{three}\\
+	& + \PT\E_{p(z|\theta)} \! \left[ c_\phi(z) \right]. \label{four}
+	\end{align}
+	Component \eqref{one} is an unbiased score-function estimator of $\frac{\partial}{\partial \theta} \mathbb{E}_{p(b \vert \theta)} \left[ f(b) \right]$. It remains to show that the other three terms are zero in expectation. Following \cite{tucker2017rebar} (see the appendices of that paper for a derivation), we rewrite component \eqref{three} as follows:
+	\begin{align}
+	-\mathbb{E}_{p(b \vert \theta)} \left[ \frac{\partial}{\partial \theta} \mathbb{E}_{p(\tilde{z} \vert b, \theta)} \left[ c_\phi (\tilde{z}) \right] \right] =~&\mathbb{E}_{p(b \vert \theta)} \left[ \mathbb{E}_{p(\tilde{z} \vert b, \theta)} \left[ c_\phi(\tilde{z}) \right] \frac{\partial}{\partial \theta} \log p(b \vert \theta) \right] \label{five} \\ & -  \mathbb{E}_{p(z \vert \theta)} \left[ c_\phi(z) \frac{\partial}{\partial \theta} \log p(z) \right] . \label{six}
+	\end{align}
+	Note that the right-hand side of equation \eqref{five} is equal to equation \eqref{two} with opposite sign. Equation \eqref{six} is the score-function estimator of equation \eqref{four}, opposite in sign. Their sum is zero in expectation.
+	\\
+\end{proof}
 
 
 \begin{algorithm}[h]


### PR DESCRIPTION
I expanded the proof in Appendix A following a conversation with Yingzhen Li after the talk I gave at Cambridge.

The unbiasedness relies on a conditional reparameterization that is not obvious if you haven't seen the result before.

This PR expands Appendix A.
@wgrathwohl 
@duvenaud 